### PR TITLE
Drops old php version support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
         }
     ],
     "require": {
-        "php": "^5.6|^7.1|^8.0"
+        "php": "^7.3|^8.0"
     },
     "require-dev": {
         "phpunit/phpunit": "*"

--- a/src/WithDictionary.php
+++ b/src/WithDictionary.php
@@ -10,7 +10,7 @@ trait WithDictionary
     /**
      * @return array
      */
-    static function all()
+    static function all(): array
     {
         $reflectionClass = new ReflectionClass(static::class);
         return $reflectionClass->getConstants();
@@ -19,16 +19,16 @@ trait WithDictionary
     /**
      * @return array
      */
-    static function values()
+    static function values(): array
     {
         return array_values(self::all());
     }
 
     /**
-     * @param string $value
+     * @param mixed $value
      * @return bool
      */
-    static function isValid($value)
+    static function isValid($value): bool
     {
         return in_array($value, self::values());
     }

--- a/tests/DictionaryCompositionTest.php
+++ b/tests/DictionaryCompositionTest.php
@@ -9,7 +9,7 @@ class DictionaryCompositionTest extends TestCase
 {
     private $vegetables;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         $this->vegetables = new CompositionTestClass();

--- a/tests/DictionaryInheritanceTest.php
+++ b/tests/DictionaryInheritanceTest.php
@@ -9,7 +9,7 @@ class DictionaryInheritanceTest extends TestCase
 {
     private $fruits;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         $this->fruits = new InheritanceTestClass();


### PR DESCRIPTION
Phpunit's `TestCase::setUp()` method use return type declaration syntax, so is not possible mantaining php 5.6.* support without creating a separate branch.